### PR TITLE
fix: improve cache mechanism for daily plugins

### DIFF
--- a/pokemon_daily/info.json
+++ b/pokemon_daily/info.json
@@ -1,7 +1,7 @@
 {
     "name": "Daily Random Pokemon",
     "description": "Daily random Pokemon from Generation 1-6 (#1-720) with image, name, number, and detailed information.",
-    "version": "0.0.1",
+    "version": "0.0.2",
     "author": "sha2kyou",
     "min_support_app_version": "2025.9.8",
     "tags": [

--- a/pokemon_daily/main.js
+++ b/pokemon_daily/main.js
@@ -6,12 +6,17 @@ function fetchEvents(config) {
     // --- 每日缓存逻辑 ---
     var today = new Date();
     var dateString = today.getFullYear() + "-" + (today.getMonth() + 1) + "-" + today.getDate();
-    var cacheKey = "pokemon_daily_v11_" + dateString;
+    var cacheKey = "pokemon_daily_v12_" + dateString;
 
     var cachedData = sdcl.storage.get(cacheKey);
     if (cachedData) {
         return cachedData;
     }
+
+    // 计算到当天结束剩余的分钟数
+    var endOfDay = new Date(today);
+    endOfDay.setHours(23, 59, 59, 999);
+    var remainingMinutes = Math.ceil((endOfDay.getTime() - today.getTime()) / (1000 * 60));
 
     // --- 随机宝可梦逻辑 ---
     var events = [];
@@ -47,9 +52,9 @@ function fetchEvents(config) {
             isPointInTime: true
         });
 
-        // 将成功获取的事件缓存24小时（1440分钟）
+        // 将成功获取的事件缓存到当天结束
         if (events.length > 0) {
-            sdcl.storage.set(cacheKey, events, 1440);
+            sdcl.storage.set(cacheKey, events, remainingMinutes);
         }
 
     } catch (err) {

--- a/unsplash_daily_theme/info.json
+++ b/unsplash_daily_theme/info.json
@@ -1,7 +1,7 @@
 {
     "name": "Unsplash 每日图片",
     "description": "每天在早10点、中午1点、下午6点，为您展示三张不同主题的精美图片。",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "author": "sha2kyou",
     "min_support_app_version": "2025.9.8",
     "tags": [

--- a/unsplash_daily_theme/main.js
+++ b/unsplash_daily_theme/main.js
@@ -12,12 +12,17 @@ function fetchEvents(config) {
     // --- 每日缓存逻辑 ---
     var today = new Date();
     var dateString = today.getFullYear() + "-" + (today.getMonth() + 1) + "-" + today.getDate();
-    var cacheKey = "unsplash_daily_theme_v1_" + dateString;
+    var cacheKey = "unsplash_daily_theme_v2_" + dateString;
 
     var cachedData = sdcl.storage.get(cacheKey);
     if (cachedData) {
         return cachedData;
     }
+
+    // 计算到当天结束剩余的分钟数
+    var endOfDay = new Date(today);
+    endOfDay.setHours(23, 59, 59, 999);
+    var remainingMinutes = Math.ceil((endOfDay.getTime() - today.getTime()) / (1000 * 60));
 
     // --- 每日主题与图片获取逻辑 ---
     var events = [];
@@ -83,9 +88,9 @@ function fetchEvents(config) {
             });
         }
 
-        // 将成功获取的事件缓存24小时（1440分钟）
+        // 将成功获取的事件缓存到当天结束
         if (events.length === 3) {
-            sdcl.storage.set(cacheKey, events, 1440);
+            sdcl.storage.set(cacheKey, events, remainingMinutes);
         } else {
             throw new Error("未能成功获取全部3张图片。");
         }


### PR DESCRIPTION
## Summary
Fix cache duration for daily plugins to use remaining minutes until end of day instead of fixed 24 hours, ensuring proper daily content refresh at midnight.

## Changes
- **Pokemon Plugin**: Update cache from v11 to v12, version 0.0.1 → 0.0.2
- **Unsplash Plugin**: Update cache from v1 to v2, version 0.1.2 → 0.1.3
- **Cache Logic**: Calculate remaining minutes until 23:59:59 instead of fixed 1440 minutes
- **Benefit**: Ensures daily content refreshes at midnight rather than 24-hour rolling window

## Technical Details
- Calculate `endOfDay` as 23:59:59.999
- Compute `remainingMinutes = Math.ceil((endOfDay.getTime() - today.getTime()) / (1000 * 60))`
- Use dynamic cache duration instead of fixed 24 hours
- Updated cache keys to invalidate old cached data

## Files Modified
- `pokemon_daily/main.js` - Cache logic and version update
- `pokemon_daily/info.json` - Version bump to 0.0.2
- `unsplash_daily_theme/main.js` - Cache logic and version update
- `unsplash_daily_theme/info.json` - Version bump to 0.1.3

## Test plan
- [ ] Cache now expires at midnight instead of 24 hours from execution
- [ ] New daily content generates correctly at midnight
- [ ] Old cached data is invalidated by version change
- [ ] Both plugins work with improved cache mechanism