### PR TITLE
feat: add V2EX Notifications plugin

### DIFF
--- a/v2ex_notifications/README.md
+++ b/v2ex_notifications/README.md
@@ -1,0 +1,21 @@
+# V2EX Notifications Plugin
+
+获取 V2EX 的未读消息并显示在日历中。支持区分回复、点赞（感谢）、提及和收藏。
+
+## 配置
+
+1. 登录 V2EX。
+2. 进入 [通知页面](https://www.v2ex.com/notifications)。
+3. 在页面右侧或底部找到 **Atom Feed for Notifications** 下面的 RSS 链接。
+4. 复制该链接中的 Token 部分（即 `.xml` 之前的长字符串，例如 `your-private-token-here`）。
+5. 将 Token 填入插件配置的 `token` 中。
+
+## 功能
+
+- **自动刷新**: 每 10 分钟检查一次新消息。
+- **类型区分**:
+  - [回复] 蓝色
+  - [感谢] 金色
+  - [提及] 红色
+  - [收藏] 橙色
+- **详情查看**: 点击事件可直接跳转到对应的回复或主题。

--- a/v2ex_notifications/info.json
+++ b/v2ex_notifications/info.json
@@ -1,0 +1,26 @@
+{
+    "name": "V2EX Notifications",
+    "description": "Fetch V2EX unread notifications via private RSS/Atom feed. Supports distinguishing between mentions, replies, and thanks.",
+    "version": "1.0.0",
+    "author": "Sidefy Team",
+    "min_support_app_version": "2025.10.7",
+    "tags": [
+        "v2ex",
+        "notifications",
+        "community",
+        "social"
+    ],
+    "category": "Social",
+    "config_options": {
+        "token": {
+            "type": "string",
+            "default": "",
+            "required": true,
+            "description": "Your V2EX private RSS token (the long string in your RSS URL)"
+        }
+    },
+    "requirements": {
+        "network": true,
+        "storage": true
+    }
+}

--- a/v2ex_notifications/main.js
+++ b/v2ex_notifications/main.js
@@ -1,0 +1,182 @@
+/**
+ * V2EX Notifications Plugin
+ * Parses V2EX private Atom feed to display notifications in the calendar.
+ */
+function fetchEvents(config) {
+    var token = config.token;
+    if (!token || token.trim() === "") {
+        throw new Error("Please configure your V2EX Private RSS Token.");
+    }
+
+    var rssUrl = "https://www.v2ex.com/n/" + token.trim() + ".xml";
+    var cacheKey = "v2ex_notifications_" + hashString(token);
+
+    // Check cache
+    var cachedData = sidefy.storage.get(cacheKey);
+    if (cachedData) {
+        return cachedData;
+    }
+
+    var events = [];
+    try {
+        var response = sidefy.http.get(rssUrl);
+        if (!response) {
+            throw new Error("Failed to fetch V2EX RSS feed.");
+        }
+
+        // Parse Atom entries
+        var entries = response.match(/<entry>[\s\S]*?<\/entry>/g);
+        if (entries) {
+            entries.forEach(function (entry) {
+                var title = extractTagContent(entry, "title");
+                var link = extractTagAttribute(entry, "link", "href");
+                var published = extractTagContent(entry, "published");
+                var contentRaw = extractTagContent(entry, "content").replace(/<!\[CDATA\[([\s\S]*?)\]\]>/g, "$1");
+                var authorName = extractTagContent(entry, "name", "<author>", "<\/author>");
+
+                var type = detectType(title, contentRaw);
+                var color = getTypeColor(type);
+
+                // Construct a meaningful title if the original is empty
+                var displayTitle = title;
+                if (!displayTitle) {
+                    if (type.id === "thanks") {
+                        displayTitle = (authorName || "有人") + " 感谢了你的回复";
+                    } else if (type.id === "favorite") {
+                        displayTitle = (authorName || "有人") + " 收藏了你的主题";
+                    } else {
+                        displayTitle = (authorName || "有人") + " 发送了新消息";
+                    }
+                }
+
+                var pubDate = new Date(published);
+                var startDate = sidefy.date.format(pubDate.getTime() / 1000);
+                var endDate = sidefy.date.format((pubDate.getTime() + 30 * 60 * 1000) / 1000);
+
+                events.push({
+                    title: displayTitle,
+                    startDate: startDate,
+                    endDate: endDate,
+                    color: color,
+                    notes: type.id === "favorite" ? null : cleanContent(contentRaw),
+                    icon: "https://www.v2ex.com/static/favicon.ico",
+                    isAllDay: false,
+                    isPointInTime: true,
+                    href: link
+                });
+            });
+        }
+
+        // Cache for 10 minutes
+        sidefy.storage.set(cacheKey, events, { ttl: 10 * 60 * 1000 });
+
+    } catch (err) {
+        sidefy.log("V2EX Plugin Error: " + err.message);
+        throw err;
+    }
+
+    return events;
+}
+
+/**
+ * Detect notification type based on title and content
+ * Based on V2EX RSS samples:
+ * - Reply/Mention: Title is not empty
+ * - Thanks (Like): Title is empty, Content is NOT empty
+ * - Favorite: Title is empty, Content is empty
+ */
+function detectType(title, content) {
+    if (!title || title.trim() === "") {
+        // If title is empty, check content to distinguish between Thanks and Favorite
+        var cleanTxt = cleanContent(content);
+        if (cleanTxt && cleanTxt.length > 0) {
+            return { id: "thanks", label: "点赞" };
+        } else {
+            return { id: "favorite", label: "收藏" };
+        }
+    }
+
+    var text = title.toLowerCase();
+    if (text.indexOf("回复了你") !== -1 || text.indexOf("回复了") !== -1) {
+        return { id: "reply", label: "回复" };
+    }
+    if (text.indexOf("感谢了你") !== -1 || text.indexOf("感谢了") !== -1) {
+        return { id: "thanks", label: "点赞" };
+    }
+    if (text.indexOf("提到你") !== -1 || text.indexOf("提到了你") !== -1) {
+        return { id: "mention", label: "提及" };
+    }
+    if (text.indexOf("收藏了") !== -1) {
+        return { id: "favorite", label: "收藏" };
+    }
+    return { id: "other", label: "通知" };
+}
+
+/**
+ * Get color for notification type
+ */
+function getTypeColor(type) {
+    var colors = {
+        "reply": "#4ECDC4",    // Cyan
+        "thanks": "#FFD93D",   // Gold
+        "mention": "#FF6B6B",  // Red
+        "favorite": "#FF8B13", // Orange
+        "other": "#95A5A6"     // Grey
+    };
+    return colors[type.id] || colors.other;
+}
+
+/**
+ * Extract content of an XML tag
+ */
+function extractTagContent(xml, tag, startBoundary, endBoundary) {
+    var searchArea = xml;
+    if (startBoundary && endBoundary) {
+        var boundaryRegex = new RegExp(startBoundary + "([\\s\\S]*?)" + endBoundary);
+        var match = xml.match(boundaryRegex);
+        if (match) searchArea = match[1];
+        else return "";
+    }
+
+    var tagRegex = new RegExp("<" + tag + "[^>]*>([\\s\\S]*?)<\\/" + tag + ">");
+    var match = searchArea.match(tagRegex);
+    return match ? match[1].trim() : "";
+}
+
+/**
+ * Extract attribute value of an XML tag
+ */
+function extractTagAttribute(xml, tag, attr) {
+    var tagRegex = new RegExp("<" + tag + "[^>]*" + attr + "=['\"]([^'\"]*)['\"][^>]*>");
+    var match = xml.match(tagRegex);
+    return match ? match[1] : "";
+}
+
+/**
+ * Clean HTML content for notes
+ */
+function cleanContent(content) {
+    if (!content) return "";
+    // Remove HTML tags
+    var text = content.replace(/<[^>]*>/g, " ");
+    // Unescape common entities
+    text = text.replace(/&nbsp;/g, " ")
+        .replace(/&quot;/g, '"')
+        .replace(/&amp;/g, "&")
+        .replace(/&lt;/g, "<")
+        .replace(/&gt;/g, ">");
+    // Clean whitespace
+    return text.trim().replace(/\s+/g, " ");
+}
+
+/**
+ * Simple hash for cache key
+ */
+function hashString(str) {
+    var hash = 0;
+    for (var i = 0; i < str.length; i++) {
+        hash = ((hash << 5) - hash) + str.charCodeAt(i);
+        hash |= 0;
+    }
+    return Math.abs(hash).toString(16);
+}


### PR DESCRIPTION
add V2EX Notifications plugin

- Support fetching unread notifications via private RSS token
- Distinguish between replies, mentions, thanks, and favorites
- Auto-generate descriptive titles for better readability
- Support color-coded events for different notification types
- Detailed notification content provided in notes (except for favorites)